### PR TITLE
Clean-up code documentation

### DIFF
--- a/fitting_models.py
+++ b/fitting_models.py
@@ -86,7 +86,7 @@ class MWCOFitting:
         
         fitted_curve = model_function(mw_range, *popt)
         
-        return mw_range, fitted_curve
+        return mw_range, fitted_curve, popt
 
 
 
@@ -208,6 +208,7 @@ class MolarVolumeRelation:
     def relation_vs_a(x):
         """
         Estimate the molar volume of a molecule based on its molecular weight using a linear relation (method a).
+        Method a: Schotte et al. group contribution theory
 
         Parameters
         ----------
@@ -217,13 +218,19 @@ class MolarVolumeRelation:
         Returns
         -------
         float
+
+        References
+        ----------
+        - William Schotte, Prediction of the molar volume at the normal boiling point, The Chemical Engineering Journal, Volume 48, Issue 3, 1992, Pages 167-172, ISSN 0300-9467
+        - https://doi.org/10.1016/0300-9467(92)80032-6
         """
-        return 1.1471 * x + 11.248
+        return 1.3348 * x - 10.552
 
     @staticmethod
     def relation_vs_b(x):
         """
         Estimate the molar volume of a molecule based on its molecular weight using a linear relation (method b).
+        Method b: Wu et al. group contribution theory
 
         Parameters
         ----------
@@ -233,8 +240,13 @@ class MolarVolumeRelation:
         Returns
         -------
         float
+
+        References
+        ----------
+        - Albert X. Wu, Sharon Lin, Katherine Mizrahi Rodriguez, Francesco M. Benedetti, Taigyu Joo, Aristotle F. Grosz, Kayla R. Storme, Naksha Roy, Duha Syar, Zachary P. Smith, Revisiting group contribution theory for estimating fractional free volume of microporous polymer membranes, Journal of Membrane Science, Volume 636, 2021, 119526, ISSN 0376-7388
+        - https://doi.org/10.1016/j.memsci.2021.119526
         """
-        return -0.0002 * (x**2) + 1.3472 * x - 4.8372
+        return 1.1353*x + 3.8219
 
     @staticmethod
     def joback(SMILES):

--- a/kenia_test.py
+++ b/kenia_test.py
@@ -1,0 +1,140 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from fitting_models import MWCOFitting, PoreSizeDistribution, MolarVolumeRelation
+from utils import StokesRadiusCalculator, DiffusivityCalculator, Solvent
+
+def main():
+    # Ruo-yu Fu (2023). Water 25C 0.890 cP https://doi.org/10.1016/j.desal.2022.116318
+    molecular_weights = [92, 122, 150,180] #g mol-1
+    rejections = [37.96,47.96,54.84,62.96] #%
+    errors = np.zeros_like(rejections)
+
+    solvent = Solvent.from_selection(1,298.15,0.89) #Water
+    mwco_line = MWCOFitting(molecular_weights,rejections,errors)
+    mw_range, fit_rej_A, _ = mwco_line.fit_curve('model_f')
+    mw_range, fit_rej_B, _ = mwco_line.fit_curve('sigmoid')
+    mw_range, fit_rej_C, _ = mwco_line.fit_curve('generalized_logistic')
+    mw_range, fit_rej_D, _ = mwco_line.fit_curve('gompertz')
+    #mw_range, fit_rej_E = mwco_line.fit_curve('double_sigmoid')
+
+    # Molar Volumes    
+    Vm_A, Vm_B = [], []
+    for i in molecular_weights:
+        x = MolarVolumeRelation.relation_vs_a(i)
+        y = MolarVolumeRelation.relation_vs_b(i)
+        Vm_A.append(x)
+        Vm_B.append(y)
+
+    # Ruo-yu Fu (2023). Water 25C 0.890 cP
+    smiles = {
+        'Glycerin': ('C(C(CO)O)O'),
+        'Erythritol': ('C([C@H]([C@H](CO)O)O)O'),
+        'Xylose': ('C1[C@H]([C@@H]([C@H](C(O1)O)O)O)O'),
+        'Glucose': ('C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O')
+    }
+    
+    Vm = []
+    for i in smiles:
+        Vc = MolarVolumeRelation.joback(smiles[i])
+        x = 0.285 * (Vc)**1.048
+        x = x * 1000
+        Vm.append(x)
+
+    print(Vm_A)
+    print(Vm_B)
+    print(Vm)
+
+    #Diffusion coefficient
+    D_A = []
+    for i in Vm_A:
+        D = DiffusivityCalculator.wilke_chang_diffusion_coefficient(i,solvent.molecular_weight,solvent.temperature,solvent.viscosity,solvent.alpha)
+        D_A.append(D)
+    print(D_A)
+
+    D_B = []
+    for i in Vm_B:
+        D = DiffusivityCalculator.wilke_chang_diffusion_coefficient(i,solvent.molecular_weight,solvent.temperature,solvent.viscosity,solvent.alpha)
+        D_B.append(D)
+    print(D_B)
+
+    D_j = []
+    for i in Vm:
+        D = DiffusivityCalculator.wilke_chang_diffusion_coefficient(i,solvent.molecular_weight,solvent.temperature,solvent.viscosity,solvent.alpha)
+        D_j.append(D)
+    print(D_j)
+
+    #radius
+    r_A = []
+    for i in D_A:
+        r = StokesRadiusCalculator.stokes_einstein_radius(i,solvent.temperature,solvent.viscosity)
+        r = r/(1e-9)
+        r_A.append(r)
+    print(r_A)
+
+    r_B = []
+    for i in D_B:
+        r = StokesRadiusCalculator.stokes_einstein_radius(i,solvent.temperature,solvent.viscosity)
+        r = r/(1e-9)
+        r_B.append(r)
+    print(r_B)
+
+    r_j = []
+    for i in D_j:
+        r = StokesRadiusCalculator.stokes_einstein_radius(i,solvent.temperature,solvent.viscosity)
+        r = r/(1e-9)
+        r_j.append(r)
+    print(r_j)
+
+    #MWCO fitting to obtain the optimal parameters
+    r_line = MWCOFitting(r_A,rejections,errors)
+    _, _, rA_opt_B = r_line.fit_curve('sigmoid')
+    _, _, rA_opt_C = r_line.fit_curve('generalized_logistic')
+    _, _, rA_opt_D = r_line.fit_curve('gompertz')
+    _, _, rA_opt_E = r_line.fit_curve('double_sigmoid')
+
+    r_line = MWCOFitting(r_B,rejections,errors)
+    _, _, rB_opt_B = r_line.fit_curve('sigmoid')
+    _, _, rB_opt_C = r_line.fit_curve('generalized_logistic')
+    _, _, rB_opt_D = r_line.fit_curve('gompertz')
+    _, _, rB_opt_E = r_line.fit_curve('double_sigmoid')
+
+    r_line = MWCOFitting(r_j,rejections,errors)
+    _, _, rj_opt_B = r_line.fit_curve('sigmoid')
+    _, _, rj_opt_C = r_line.fit_curve('generalized_logistic')
+    _, _, rj_opt_D = r_line.fit_curve('gompertz')
+    _, _, rj_opt_E = r_line.fit_curve('double_sigmoid')
+
+    #Pore Size Distribution
+    x = np.linspace(0.01, 1, 100)  # Random pore sizes
+    # log-normal PDF
+    avg_radius = 0.3
+    std_dev = 0.1
+    psd_A = PoreSizeDistribution.calculate_psd(x,avg_radius,std_dev)
+
+    # Derivative Sigmoid
+    psd_j_B = PoreSizeDistribution.derivative_sigmoid(x,*rj_opt_B)
+
+    # Derivative Generalized Logistic
+    psd_j_C = PoreSizeDistribution.derivative_generalized_logistic(x,*rj_opt_C)
+
+    # Derivative Gompertz
+    psd_j_D = PoreSizeDistribution.derivative_gompertz(x,*rj_opt_D)
+
+    # Derivative Double Sigmoid
+    psd_j_E = PoreSizeDistribution.derivative_double_sigmoid(x,*rj_opt_E)
+
+    plt.plot(x,psd_A, color='r',label='PDF')
+    plt.plot(x,psd_j_B, color='b',label='Derivative Sigmoid')
+    plt.plot(x,psd_j_C, color='k',label='Derivative g(x)')
+    plt.plot(x,psd_j_D, color='y',label='Derivative Gompertz')
+    plt.plot(x,psd_j_E, color='g',label='Derivative Double Sigmoid')
+    plt.xlabel('radius (nm)')
+    plt.ylabel('(a.u.)')
+    plt.title('PSD')
+    plt.legend()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import numpy as np
+import matplotlib.pyplot as plt
 
 from fitting_models import MWCOFitting, PoreSizeDistribution, MolarVolumeRelation
 from utils import StokesRadiusCalculator, DiffusivityCalculator, Solvent
@@ -9,7 +10,7 @@ def main():
     errors = np.zeros_like(rejections)
 
     mwco_fitting = MWCOFitting(molecular_weights, rejections, errors)
-    mw_range, fitted_curve = mwco_fitting.fit_curve('model_f')
+    mw_range, fitted_curve, _ = mwco_fitting.fit_curve('model_f')
 
     print("MWCO Curve Fit:")
     print("Molecular Weights Range:", mw_range)

--- a/utils.py
+++ b/utils.py
@@ -2,22 +2,22 @@ import numpy as np
 
 class StokesRadiusCalculator:
     @staticmethod
-    def stokes_einstein_radius(D):
+    def stokes_einstein_radius(D,T,eta):
         """
         Calculate the radius of a particle from the diffusion coefficient using the Stokes-Einstein equation.
 
         Parameters:
         D (float): Diffusion coefficient (cm²/s)
         T (float): Absolute temperature (K)
-        eta (float): Dynamic viscosity of the fluid (Pa·s)
+        eta (float): Dynamic viscosity of the fluid (cP)
 
         Returns:
         float: Radius of the particle (m)
         """
         # Boltzmann constant in J/K
-        T = 298.15  # Absolute temperature in Kelvin
-        eta = 0.334*0.001  # Dynamic viscosity of acetonitrile at 25°C in Pa·s (or kg/(m·s))
         k_B = 1.380649e-23
+        # Convert dynamic viscosity from cP to kg/(m·s) (or Pa·s)
+        eta = eta*0.001
         
         # Convert diffusion coefficient from cm²/s to m²/s
         D = D * 1e-4
@@ -31,7 +31,9 @@ class StokesRadiusCalculator:
 class DiffusivityCalculator:
     @staticmethod
     def wilke_chang_diffusion_coefficient(molar_volume, molecular_weight, temp, viscosity, alpha):
-        return (7.4E-8) * temp * np.sqrt(alpha * molecular_weight) / (viscosity * (alpha * molar_volume)**0.6)
+        d = (7.4E-8) * temp * np.sqrt(alpha * molecular_weight) / (viscosity * (alpha * molar_volume)**0.6)
+        d = float(d) # The value was being printed like: [np.float64(5.497635472812708e-06), np.float64(4.708457138648548e-06), np.float64(4.194534214640366e-06), np.float64(3.7831496747983576e-06)]
+        return d
 
 
 


### PR DESCRIPTION
- Changes in joback branch
- Added the return of optimal values to fit_curve
- Changed relation_vs_a with a linear regression from Schotte et al.
- Changed relation_vs_b with a linear regresion from Wu et al.
- Added the T and eta parameters in stokes_einstein_radius
- Changed the description of the method. eta should be input in cP, not Pa.s
- Added float command in wilke_chang_diffusion_coefficient. For some reason it was printing the value like: np.float64(5.497635472812708e-06)
- Added a discard operator ( _ ) in main so it could run normally: line 13

kenia_test.py tries all the modules